### PR TITLE
Example: change wdi5 type to promise

### DIFF
--- a/app/samples/webapp/test/wdi5/pages/ObjectPage.ts
+++ b/app/samples/webapp/test/wdi5/pages/ObjectPage.ts
@@ -1,5 +1,12 @@
 import type List from "sap/m/List";
 import {wdi5Selector} from "wdio-ui5-service";
+import type { WDI5Control } from "wdio-ui5-service/cjs/lib/wdi5-control";
+
+type MapFunctionToPromise<T> = T extends (...args: infer A) => infer R ? (...args: A) => Promise<R> : T;
+
+type Promised<T> = WDI5Control & {
+    [K in keyof T]: MapFunctionToPromise<T[K]>;
+}
 
 // open: typed UI5 controls retrieved from the browser-scope (see https://github.com/ui5-community/wdi5/issues/509)
 
@@ -12,8 +19,7 @@ class ObjectPage {
                 id: RegExp("CommentsList")
             }
         };
-        const commentsList = await browser.asControl<List>(commentsListSelector);
-        // eslint-disable-next-line @typescript-eslint/await-thenable
+        const commentsList = await browser.asControl<List>(commentsListSelector) as unknown as Promised<List>;
         const commentsListItems = await commentsList.getItems();
         await expect(commentsListItems.length).toEqual(numberOfEntries);
     }


### PR DESCRIPTION
Wdi5 currently has an issue with the UI5 types because it uses them as is but actually those are wrapped as promises when testing with wdi5 (https://github.com/ui5-community/wdi5/issues/509).

This example fixes the type issue by providing a generic type `Promised<T>` that can be used to convert the UI5 types to promises.

todo: test `import { promisify } from 'util';`